### PR TITLE
Fix typo in Mac & Cheese recipe

### DIFF
--- a/fall_favorites/mac_and_cheese.md
+++ b/fall_favorites/mac_and_cheese.md
@@ -19,7 +19,7 @@ Yields 12-14 servings
 
 ### Seasonings
 
-- 5 spirgs thyme (Optional)
+- 5 Sprigs thyme (Optional)
 - Paprika
 - Salt
 - Pepper


### PR DESCRIPTION
Corrected "spirg" to "sprig" and made capitalization consistent in section.